### PR TITLE
Always return an ItemLookupResponse object

### DIFF
--- a/amazon/item_lookup.go
+++ b/amazon/item_lookup.go
@@ -133,10 +133,10 @@ func (req *ItemLookupRequest) operation() string {
 func (req *ItemLookupRequest) Do() (*ItemLookupResponse, error) {
 	respObj := ItemLookupResponse{}
 	if _, err := req.Client.DoRequest(req, &respObj); err != nil {
-		return nil, err
+		return &respObj, err
 	}
 	if err := respObj.Error(); err != nil {
-		return nil, err
+		return &respObj, err
 	}
 	return &respObj, nil
 }


### PR DESCRIPTION
This is a proposal to change the response of the ItemLookupRequest.Do function when it gets a error, so that the function would always return an ItemLookupResponse object instead of a nil value as it does now.

This will fix the particular problem of calling the Do function to lookup several items in which some of them have an invalid ASIN code. In this case, Amazon will still send back the data for the "good" items, so we are losing that information by returning nil.