### PR TITLE
add parent ASIN

### DIFF
--- a/amazon/error.go
+++ b/amazon/error.go
@@ -111,7 +111,7 @@ func (e Errors) Error() string {
 // ErrorResponse represents error response from the API
 type ErrorResponse interface {
 	error
-	Code() string
+	Code() ErrorCode
 	Message() string
 }
 

--- a/amazon/item.go
+++ b/amazon/item.go
@@ -19,6 +19,7 @@ type Items struct {
 type Item struct {
 	XMLName         xml.Name `xml:"Item"`
 	ASIN            string
+	ParentASIN      string
 	DetailPageURL   string
 	SalesRank       int
 	ItemLinks       ItemLinks


### PR DESCRIPTION
Great implementation of the API, saves me so much work.

I need the parent ASIN to look up the parent for a variant. This is returned in the affiliate API but missing in the struct.